### PR TITLE
Update index.tsx [Directions Event Solution page]

### DIFF
--- a/client/pages/solutions/directions-event/index.tsx
+++ b/client/pages/solutions/directions-event/index.tsx
@@ -235,7 +235,7 @@ const PuzzleSolution: FC<PuzzleDataProps> = ({ puzzleData }) => (
     </p>
     <p>
       <b>Acknowledgements:</b> This puzzle draws inspiration from Dimension 20's{' '}
-      <i>Game Changer</i>, which played a similar game for groups of thre called{' '}
+      <i>Game Changer</i>, which played a similar game for groups of three called{' '}
       <i>
         <a href="https://www.youtube.com/watch?v=vT-zZsjwZKk">Sam Says</a>
       </i>


### PR DESCRIPTION
Fixed spelling error on Directions Event Solution page (Acknowledgments previously listed "This puzzle draws inspiration from...for groups of thre", should read "three"

You can ignore / delete any irrelevant sections

---

## Postprod

Puzzle URL: <replace_me>

- [ ] The puzzle's hints have been exported from Puzzup.
- [ ] The puzzle has an emoji in its yaml data.
- [ ] The puzzle looks "nice" on the branch frontend.
  - [ ] Cluephrases and the like are in `<Clue>` or `<Monospace>` tags for monospace font.
  - [ ] Tables are preferred over paragraphs for data.
- [ ] The puzzle solution looks "nice" on the branch frontend.
- [ ] Images that require attribution have are attributed on the solution page.

---

## Frontend (Next.js)

Frontend changes URL: <replace_me>

Affected page URLS:

- <url_1>

---

## Backend (Django)

- [ ] I have verified that these changes work when run locally.
- [ ] `mypy server` passes
